### PR TITLE
Fix memory leak in build_from_metis and build_from_metis_weighted

### DIFF
--- a/LMCHGP/lib/data_structure/graph_access.h
+++ b/LMCHGP/lib/data_structure/graph_access.h
@@ -522,6 +522,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -542,6 +545,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 

--- a/SOCIAL/lib/data_structure/graph_access.h
+++ b/SOCIAL/lib/data_structure/graph_access.h
@@ -522,6 +522,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -542,6 +545,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 

--- a/experimental_data/Faster Local Motif Clustering via Maximum Flows/algorithms/LMCHGP/lib/data_structure/graph_access.h
+++ b/experimental_data/Faster Local Motif Clustering via Maximum Flows/algorithms/LMCHGP/lib/data_structure/graph_access.h
@@ -522,6 +522,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -542,6 +545,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 

--- a/experimental_data/Faster Local Motif Clustering via Maximum Flows/algorithms/SOCIAL/lib/data_structure/graph_access.h
+++ b/experimental_data/Faster Local Motif Clustering via Maximum Flows/algorithms/SOCIAL/lib/data_structure/graph_access.h
@@ -522,6 +522,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -542,6 +545,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 

--- a/experimental_data/Local Motif Clustering via (Hyper)Graph Partitioning/algorithms/lib/data_structure/graph_access.h
+++ b/experimental_data/Local Motif Clustering via (Hyper)Graph Partitioning/algorithms/lib/data_structure/graph_access.h
@@ -522,6 +522,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -542,6 +545,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 

--- a/experimental_data/Local Motif Clustering via (Hyper)Graph Partitioning/full_algorithms/lib/data_structure/graph_access.h
+++ b/experimental_data/Local Motif Clustering via (Hyper)Graph Partitioning/full_algorithms/lib/data_structure/graph_access.h
@@ -522,6 +522,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -542,6 +545,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+        if(graphref != NULL) {
+                delete graphref;
+        }
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 


### PR DESCRIPTION
## Summary
- `build_from_metis` and `build_from_metis_weighted` overwrite `graphref` with a new `basicGraph` allocation without freeing the previous one, leaking memory on every call
- Adds a null-checked `delete` before the new allocation, consistent across all 6 copies (SOCIAL, LMCHGP, and experimental_data)

## Context
When using the library via Python/pybind11 bindings, the leaked `basicGraph` objects cause heap corruption detected by glibc during process cleanup (`free(): invalid pointer`).

## Test plan
- [x] Verified fix resolves the heap corruption when called from Python bindings
- [x] All 8 motif clustering tests pass (SOCIAL and LMCHGP)